### PR TITLE
storagePathPostfix config added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: support multiple SDK instances with same API key ([#1](https://github.com/worldcoin/posthog-ios/pull/1))
+
 ## 3.20.1 - 2025-03-13
 
 - fix: disk storage not working on tvOS ([#316](https://github.com/PostHog/posthog-ios/pull/316))

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "3ef6999c73b6938cc0da422f2c912d0158abb0a0",
-          "version": "2.2.0"
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "2ef56b2caf25f55fa7eef8784c30d5a767550f54",
-          "version": "2.2.1"
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
         }
       },
       {

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -60,6 +60,8 @@ import Foundation
     /// Do not modify it, this flag is read and updated by the SDK via feature flags
     @objc public var snapshotEndpoint: String = "/s/"
 
+    @objc public var storagePathPostfix: String? = nil
+
     /// or EU Host: 'https://eu.i.posthog.com'
     public static let defaultHost: String = "https://us.i.posthog.com"
 

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -224,6 +224,7 @@ class PostHogStorage {
     private static func getAppFolderUrl(from configuration: PostHogConfig) -> URL {
         let apiDir = getBaseAppFolderUrl(from: configuration)
             .appendingPathComponent(configuration.apiKey)
+            .appendingPathComponent(configuration.storagePathPostfix ?? "")
 
         createDirectoryAtURLIfNeeded(url: apiDir)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We want to be able to use multiple Posthog instances with the same API key. For this to work we need them to use a storage with different paths.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
